### PR TITLE
fix: Ignore undefined style values on native

### DIFF
--- a/packages/react-strict-dom/src/native/css/processStyle.js
+++ b/packages/react-strict-dom/src/native/css/processStyle.js
@@ -73,6 +73,13 @@ export function processStyle(
   for (const propName in style) {
     const styleValue = style[propName];
 
+    // Drop undefined values so they don't reach the style resolver, which
+    // only accepts strings, numbers, objects, or null. This matches web
+    // behavior and lets style functions return undefined to omit a property.
+    if (styleValue === undefined) {
+      continue;
+    }
+
     if (skipValidation !== true && !isAllowedStyleKey(propName)) {
       if (__DEV__) {
         warnMsg(`unsupported style property "${propName}"`);

--- a/packages/react-strict-dom/tests/css/css-create-test.native.js
+++ b/packages/react-strict-dom/tests/css/css-create-test.native.js
@@ -2102,6 +2102,22 @@ describe('css.create()', () => {
       });
       expect(root.toJSON().props.style).toMatchSnapshot();
     });
+
+    test('undefined values are ignored', () => {
+      const styles = css.create({
+        root: (gap) => ({
+          rowGap: gap
+        })
+      });
+      let root;
+      act(() => {
+        root = create(<html.div style={styles.root(undefined)} />);
+      });
+      const { style } = root.toJSON().props;
+      // The property is dropped rather than passed through as undefined,
+      // which would otherwise be rejected by the style resolver.
+      expect(Object.prototype.hasOwnProperty.call(style, 'rowGap')).toBe(false);
+    });
   });
 
   /**


### PR DESCRIPTION
Fixes https://github.com/react/react-strict-dom/issues/452

* Ignore undefined style values on native
* Drop undefined properties in processStyle so they never reach styleq.
* This matches web behavior and lets style functions omit a property.